### PR TITLE
Patch when globalMaxCommission is unset

### DIFF
--- a/src/contexts/Pools/PoolsConfig/index.tsx
+++ b/src/contexts/Pools/PoolsConfig/index.tsx
@@ -122,7 +122,7 @@ export const PoolsConfigProvider = ({
               minCreateBond: new BigNumber(minCreateBond.toString()),
               minJoinBond: new BigNumber(minJoinBond.toString()),
               globalMaxCommission: Number(
-                globalMaxCommission.toHuman().slice(0, -1)
+                globalMaxCommission?.toHuman()?.slice(0, -1) ?? 1 // if unset, the max is 100%
               ),
             },
           },


### PR DESCRIPTION
this was originally proposed as part of other unrelated changes in: https://github.com/gluwa/creditcoin-staking-dashboard/pull/122/commits/8aa2536c9cd061c3fd7dcca5908dd8a57b9fb76b#diff-c8e61cb82ce02ac86bb000a644b7622854f4f856d6b622c5a53634e509440afe

which is represented in this repository by commit
8aa2536c9cd061c3fd7dcca5908dd8a57b9fb76b and was later reverted in c232132108eef7dd3c3996294ff571c2885f987f

This commit brings back this change!