### PR TITLE
CSUB-946 wrong pending rewards calculation

### DIFF
--- a/src/contexts/Payouts/index.tsx
+++ b/src/contexts/Payouts/index.tsx
@@ -151,13 +151,16 @@ export const PayoutsProvider = ({
     // Helper function to check which eras a validator was exposed in.
     const validatorExposedEras = (validator: string) => {
       const exposedEras: string[] = [];
-      for (const era of erasToCheck)
+      for (const era of erasToCheck) {
         if (
-          Object.values(
-            Object.keys(getLocalEraExposure(network, era, activeAccount))
-          )?.[0] === validator
+          (
+            Object.values(
+              Object.keys(getLocalEraExposure(network, era, activeAccount))
+            ) ?? []
+          ).includes(validator)
         )
           exposedEras.push(era);
+      }
       return exposedEras;
     };
 


### PR DESCRIPTION
Fixed
- Increased `MaxSupportedPayoutEras` to 84.
- Check all validators instead of the first one.

One important thing is to clear the browser local storage before restart the chain and run the dashboard.

<img width="798" alt="nominate___Creditcoin" src="https://github.com/gluwa/creditcoin3-staking-dashboard/assets/51565705/b863b251-433e-4ed4-bebd-e0e9c055e634">

If it is not cleared, then the calculation will include the previous chain's values.
