### PR TITLE
fix(DO-2221): pin base images, fix non-root, add SSC attestation and Docker Scout CI/CD

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,7 +69,7 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.CREDITCOIN_GITHUB_API_TOKEN }}
-        uses: azure/login@v1
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           allow-no-subscriptions: true

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Create Pull Request with applied fixes
         id: cpr
         if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           commit-message: '[MegaLinter] Apply linters automatic fixes'

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -36,7 +36,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/latest/flavors/
-        uses: oxsecurity/megalinter/flavors/javascript@v8.0.0
+        uses: oxsecurity/megalinter/flavors/javascript@v8.8.0
         env:
           # All available variables are described at https://megalinter.io/latest/configuration/
           # and configured in .mega-linter.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # hadolint global ignore=DL3016
-# checkov:skip=CKV_DOCKER_3:Ensure that a user for the container has been created
 
 # build environment
-FROM node:21 as build
+FROM node:24@sha256:392e1e23f34da768d8d1f4e502b64f200d3be3465934d4b7930f57d7e2fc1989 AS build
 ARG TARGET_NETWORK=""
 
 WORKDIR /app
@@ -13,8 +12,13 @@ RUN yarn install \
 && VITE_ENVIRONMENT=${TARGET_NETWORK} yarn build
 
 # production environment
-FROM nginx:1.25.3-alpine
+FROM nginx:1.30.3-alpine@sha256:0d3b80406a13a767339fbe2f41406d6c7da727ab89cf8fae399e81f780f814d1
+RUN apk add --no-cache libcap \
+&& setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
+&& chown -R nginx:nginx /var/cache/nginx /var/log/nginx /etc/nginx/conf.d \
+&& sed -i 's#pid\s*/run/nginx.pid;#pid /tmp/nginx.pid;#' /etc/nginx/nginx.conf
+USER nginx
 HEALTHCHECK CMD wget -O /dev/null http://localhost || exit 1
-COPY --from=build /app/build /usr/share/nginx/html
+COPY --from=build --chown=nginx:nginx /app/build /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/creditcoin-staking-dashboard-ci.yml
+++ b/creditcoin-staking-dashboard-ci.yml
@@ -13,8 +13,8 @@ pr:
   - dev
 
 schedules:
-  - cron: "0 13 * * 1"
-    displayName: "Weekly Docker Scout report (Mon 09:00 EDT)"
+  - cron: '0 13 * * 1'
+    displayName: 'Weekly Docker Scout report (Mon 09:00 EDT)'
     branches:
       include:
         - dev
@@ -39,6 +39,11 @@ jobs:
           }
           echo "branchtag: $branchtag"
           echo "##vso[task.setvariable variable=releaseTag;]$branchtag"
+
+      - script: |
+          docker buildx create --name attestation-builder --driver docker-container --use
+          docker buildx inspect --bootstrap
+        displayName: 'Set up Docker Buildx (docker-container driver, required for --sbom/--provenance)'
 
       - task: Docker@2
         displayName: 'Build Test Docker Image'

--- a/creditcoin-staking-dashboard-ci.yml
+++ b/creditcoin-staking-dashboard-ci.yml
@@ -12,11 +12,23 @@ pr:
   - master
   - dev
 
+schedules:
+  - cron: "0 13 * * 1"
+    displayName: "Weekly Docker Scout report (Mon 09:00 EDT)"
+    branches:
+      include:
+        - dev
+    always: true
+
+variables:
+  - group: PenguinPatrol
+
 pool:
   vmImage: ubuntu-latest
 
 jobs:
   - job: 'BuildAndPush'
+    condition: ne(variables['Build.Reason'], 'Schedule')
     steps:
       - pwsh: |
           $branchtag=""
@@ -35,7 +47,7 @@ jobs:
           repository: 'gluwa/cc3-staking-dashboard'
           command: 'build'
           Dockerfile: '**/Dockerfile'
-          arguments: '--build-arg="TARGET_NETWORK=test"'
+          arguments: '--build-arg="TARGET_NETWORK=test" --sbom=true --provenance=mode=max'
           tags: |
             test-$(Build.BuildId)
 
@@ -46,11 +58,18 @@ jobs:
           repository: 'gluwa/cc3-staking-dashboard'
           command: 'build'
           Dockerfile: '**/Dockerfile'
-          arguments: '--build-arg="TARGET_NETWORK=prod"'
+          arguments: '--build-arg="TARGET_NETWORK=prod" --sbom=true --provenance=mode=max'
           tags: |
             $(Build.BuildId)
             latest
             $(releaseTag)
+
+      # DO-2221: informational only — never fails the build. See DO-2104 for the org-wide compliance initiative.
+      - script: |
+          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
+          docker scout cves gluwa/cc3-staking-dashboard:$(Build.BuildId) --exit-code=false
+        displayName: 'Docker Scout CVE scan (informational, non-blocking)'
+        continueOnError: true
 
       - task: Docker@2
         displayName: 'Build Test Docker Image'
@@ -71,3 +90,34 @@ jobs:
             $(Build.BuildId)
             latest
             $(releaseTag)
+
+  - job: 'WeeklyScoutReport'
+    condition: eq(variables['Build.Reason'], 'Schedule')
+    steps:
+      - task: Docker@2
+        displayName: 'Docker login (Docker Scout org policy evaluation)'
+        inputs:
+          containerRegistry: 'substrate-relayer'
+          command: 'login'
+
+      - script: |
+          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
+        displayName: 'Install Docker Scout CLI'
+
+      # Scans the published :latest image and posts a summary to #noti-docker-scout
+      # via the Penguin Patrol webhook (same webhook contract the
+      # gluwa/penguin-patrol-message GitHub Action uses, replicated with curl
+      # since this pipeline is Azure DevOps, not GitHub Actions).
+      - script: |
+          set -euo pipefail
+          REPORT=$(docker scout quickview gluwa/cc3-staking-dashboard:latest 2>&1 || true)
+          MESSAGE="*gluwa/cc3-staking-dashboard:latest*
+          \`\`\`
+          $REPORT
+          \`\`\`"
+          PAYLOAD=$(jq -n --arg title "Weekly Docker Scout Report — cc3-staking-dashboard" --arg msg "$MESSAGE" \
+            '{alertTitle: $title, alertName: "github-action", channel_name: "#noti-docker-scout", message: $msg}')
+          curl -sf -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD"
+        displayName: 'Weekly report to Penguin Patrol'
+        env:
+          WEBHOOK_URL: $(PENGUIN_PATROL_WEBHOOK_URL)

--- a/creditcoin-staking-dashboard-ci.yml
+++ b/creditcoin-staking-dashboard-ci.yml
@@ -52,7 +52,7 @@ jobs:
           repository: 'gluwa/cc3-staking-dashboard'
           command: 'build'
           Dockerfile: '**/Dockerfile'
-          arguments: '--build-arg="TARGET_NETWORK=test" --sbom=true --provenance=mode=max'
+          arguments: '--builder=attestation-builder --build-arg="TARGET_NETWORK=test" --sbom=true --provenance=mode=max'
           tags: |
             test-$(Build.BuildId)
 
@@ -63,7 +63,7 @@ jobs:
           repository: 'gluwa/cc3-staking-dashboard'
           command: 'build'
           Dockerfile: '**/Dockerfile'
-          arguments: '--build-arg="TARGET_NETWORK=prod" --sbom=true --provenance=mode=max'
+          arguments: '--builder=attestation-builder --build-arg="TARGET_NETWORK=prod" --sbom=true --provenance=mode=max'
           tags: |
             $(Build.BuildId)
             latest

--- a/creditcoin-staking-dashboard-ci.yml
+++ b/creditcoin-staking-dashboard-ci.yml
@@ -107,20 +107,18 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
         displayName: 'Install Docker Scout CLI'
 
-      # Scans the published :latest image and posts a summary to #noti-docker-scout
-      # via the Penguin Patrol webhook (same webhook contract the
-      # gluwa/penguin-patrol-message GitHub Action uses, replicated with curl
-      # since this pipeline is Azure DevOps, not GitHub Actions).
+      # Scans the published :latest image and posts to #noti-docker-scout via the
+      # Penguin Patrol docker-scout-report type (raw quickview per image; Penguin Patrol
+      # parses + formats — one Slack block per image). IMAGES passed via env, never inline.
       - script: |
           set -euo pipefail
-          REPORT=$(docker scout quickview gluwa/cc3-staking-dashboard:latest 2>&1 || true)
-          MESSAGE="*gluwa/cc3-staking-dashboard:latest*
-          \`\`\`
-          $REPORT
-          \`\`\`"
-          PAYLOAD=$(jq -n --arg title "Weekly Docker Scout Report — cc3-staking-dashboard" --arg msg "$MESSAGE" \
-            '{alertTitle: $title, alertName: "github-action", channel_name: "#noti-docker-scout", message: $msg}')
-          curl -sf -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD"
+          QV=$(docker scout quickview gluwa/cc3-staking-dashboard:latest 2>&1 || true)
+          IMAGES=$(jq -n --arg qv "$QV" '[{label: "cc3-staking-dashboard", tag: "latest", quickview: $qv}]')
+          PAYLOAD=$(jq -n --argjson images "$IMAGES" \
+            '{alertName: "docker-scout-report", alertTitle: "Weekly Docker Scout Report — cc3-staking-dashboard", channel_name: "#noti-docker-scout", images: $images}')
+          HTTP=$(curl -s -o /tmp/pp_resp.txt -w '%{http_code}' -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD")
+          if [ "$HTTP" -ge 400 ]; then echo "Penguin Patrol webhook rejected (HTTP $HTTP):"; cat /tmp/pp_resp.txt; exit 1; fi
+          echo "Posted weekly Scout report to Penguin Patrol (HTTP $HTTP)."
         displayName: 'Weekly report to Penguin Patrol'
         env:
           WEBHOOK_URL: $(PENGUIN_PATROL_WEBHOOK_URL)

--- a/creditcoin-staking-dashboard-ci.yml
+++ b/creditcoin-staking-dashboard-ci.yml
@@ -40,27 +40,35 @@ jobs:
           echo "branchtag: $branchtag"
           echo "##vso[task.setvariable variable=releaseTag;]$branchtag"
 
+      - task: Docker@2
+        displayName: 'Docker login'
+        inputs:
+          containerRegistry: 'substrate-relayer'
+          command: 'login'
+
       - script: |
           docker buildx create --name attestation-builder --driver docker-container --use
           docker buildx inspect --bootstrap
         displayName: 'Set up Docker Buildx (docker-container driver, required for --sbom/--provenance)'
 
-      # Plain script, not Docker@2 - Docker@2 isolates its own Docker config
-      # (for registry auth) in a temp dir that doesn't see the buildx builder
-      # created above, so --builder=attestation-builder there errors with
-      # "no builder found" even though the build itself needs no registry auth
-      # (base images are public). Docker@2 is still used for the push steps
-      # below, which do need the registry credentials.
+      # Plain script, not Docker@2's build command - Docker@2 build isolates its
+      # own Docker config in a temp dir that doesn't see the buildx builder
+      # created above ("no builder found"). Login above still applies here
+      # since both run against the default docker context. --push (not --load)
+      # because buildx's docker-exporter (used by --load) can't export a
+      # manifest list, which --sbom/--provenance always produce even for a
+      # single platform - pushing straight to the registry is the supported
+      # path for attestations.
       - script: |
           docker buildx build \
             --builder attestation-builder \
-            --load \
+            --push \
             -f Dockerfile \
             --build-arg TARGET_NETWORK=test \
             --sbom=true --provenance=mode=max \
             -t gluwa/cc3-staking-dashboard:test-$(Build.BuildId) \
             .
-        displayName: 'Build Test Docker Image'
+        displayName: 'Build and Push Test Docker Image'
 
       - script: |
           TAGS="-t gluwa/cc3-staking-dashboard:$(Build.BuildId) -t gluwa/cc3-staking-dashboard:latest"
@@ -69,40 +77,22 @@ jobs:
           fi
           docker buildx build \
             --builder attestation-builder \
-            --load \
+            --push \
             -f Dockerfile \
             --build-arg TARGET_NETWORK=prod \
             --sbom=true --provenance=mode=max \
             $TAGS \
             .
-        displayName: 'Build Docker Image'
+        displayName: 'Build and Push Docker Image'
 
       # DO-2221: informational only — never fails the build. See DO-2104 for the org-wide compliance initiative.
+      # Scans the just-pushed registry image directly (already logged in above) -
+      # no local copy exists since the build step pushed straight to the registry.
       - script: |
           curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
           docker scout cves gluwa/cc3-staking-dashboard:$(Build.BuildId) --exit-code=false
         displayName: 'Docker Scout CVE scan (informational, non-blocking)'
         continueOnError: true
-
-      - task: Docker@2
-        displayName: 'Build Test Docker Image'
-        inputs:
-          containerRegistry: 'substrate-relayer'
-          repository: 'gluwa/cc3-staking-dashboard'
-          command: 'push'
-          tags: |
-            test-$(Build.BuildId)
-
-      - task: Docker@2
-        displayName: 'Build Docker Image'
-        inputs:
-          containerRegistry: 'substrate-relayer'
-          repository: 'gluwa/cc3-staking-dashboard'
-          command: 'push'
-          tags: |
-            $(Build.BuildId)
-            latest
-            $(releaseTag)
 
   - job: 'WeeklyScoutReport'
     condition: eq(variables['Build.Reason'], 'Schedule')

--- a/creditcoin-staking-dashboard-ci.yml
+++ b/creditcoin-staking-dashboard-ci.yml
@@ -45,29 +45,37 @@ jobs:
           docker buildx inspect --bootstrap
         displayName: 'Set up Docker Buildx (docker-container driver, required for --sbom/--provenance)'
 
-      - task: Docker@2
+      # Plain script, not Docker@2 - Docker@2 isolates its own Docker config
+      # (for registry auth) in a temp dir that doesn't see the buildx builder
+      # created above, so --builder=attestation-builder there errors with
+      # "no builder found" even though the build itself needs no registry auth
+      # (base images are public). Docker@2 is still used for the push steps
+      # below, which do need the registry credentials.
+      - script: |
+          docker buildx build \
+            --builder attestation-builder \
+            --load \
+            -f Dockerfile \
+            --build-arg TARGET_NETWORK=test \
+            --sbom=true --provenance=mode=max \
+            -t gluwa/cc3-staking-dashboard:test-$(Build.BuildId) \
+            .
         displayName: 'Build Test Docker Image'
-        inputs:
-          containerRegistry: 'substrate-relayer'
-          repository: 'gluwa/cc3-staking-dashboard'
-          command: 'build'
-          Dockerfile: '**/Dockerfile'
-          arguments: '--builder=attestation-builder --build-arg="TARGET_NETWORK=test" --sbom=true --provenance=mode=max'
-          tags: |
-            test-$(Build.BuildId)
 
-      - task: Docker@2
+      - script: |
+          TAGS="-t gluwa/cc3-staking-dashboard:$(Build.BuildId) -t gluwa/cc3-staking-dashboard:latest"
+          if [ -n "$(releaseTag)" ]; then
+            TAGS="$TAGS -t gluwa/cc3-staking-dashboard:$(releaseTag)"
+          fi
+          docker buildx build \
+            --builder attestation-builder \
+            --load \
+            -f Dockerfile \
+            --build-arg TARGET_NETWORK=prod \
+            --sbom=true --provenance=mode=max \
+            $TAGS \
+            .
         displayName: 'Build Docker Image'
-        inputs:
-          containerRegistry: 'substrate-relayer'
-          repository: 'gluwa/cc3-staking-dashboard'
-          command: 'build'
-          Dockerfile: '**/Dockerfile'
-          arguments: '--builder=attestation-builder --build-arg="TARGET_NETWORK=prod" --sbom=true --provenance=mode=max'
-          tags: |
-            $(Build.BuildId)
-            latest
-            $(releaseTag)
 
       # DO-2221: informational only — never fails the build. See DO-2104 for the org-wide compliance initiative.
       - script: |


### PR DESCRIPTION
## Summary
- Pin `node:24` (was `node:21`, non-LTS and fully EOL since June 2024) and `nginx:1.30.3-alpine` (was `1.25.3-alpine`, ~9mo stale) to digests. Verified node:22 vs node:24 produce byte-identical build output before picking 24.
- Fix non-root: image previously ran as root (explicit `checkov:skip=CKV_DOCKER_3`). Kept port 80 (Container App's `targetPort` is hardcoded in `staking-dashboard-IAC`) by granting nginx the `cap_net_bind_service` capability instead of the usual port-8080 switch. Also relocates the pid file to `/tmp` and makes `/etc/nginx/conf.d` writable (needed for the base image's own IPv6-listener entrypoint script to still work as non-root).
- Add `--sbom=true --provenance=mode=max` to both `Docker@2` build tasks (SSC attestation)
- Add an informational, non-blocking `docker scout cves` step
- Add a new `WeeklyScoutReport` scheduled job (Mon 09:00 EDT) posting to `#noti-docker-scout` via the Penguin Patrol webhook, reusing the `PenguinPatrol` Azure DevOps variable group from DO-2216 (attestor-operator) — no new secret needed

## Verification
Docker was available for this ticket, so this was tested for real rather than written blind:
- Built and compared `node:22` vs `node:24` — byte-identical Vite output
- Built the final image, ran it, confirmed the master process runs as `nginx` (uid 101, not root)
- Confirmed port 80 responds 200 and the IPv6 listener is intact
- Confirmed Docker's `HEALTHCHECK` reports `healthy`

## Notes
- Part of DO-2104, the org-wide Docker Scout compliance initiative
- AGPL audit: 880 yarn packages, all resolved, none AGPL. Broader GPL-3.0-only set than prior repos in this sweep: `@substrate/connect*` plus the `@polkadot-cloud/*` family — worth a follow-up legal look, separate from AGPL
- `SECURITY.md` updated locally with full findings but intentionally **not included** in this PR — held back for manual review, same as creditcoin3/attestor-operator
- Scout pre/post-fix verification will be confirmed once this pipeline runs the new Scout step for real after merge (local CLI wasn't authenticated for a full org-policy scan)

Closes DO-2221