### PR TITLE
fix: authenticate Docker Scout weekly report via plain docker login

### DIFF
--- a/creditcoin-staking-dashboard-ci.yml
+++ b/creditcoin-staking-dashboard-ci.yml
@@ -90,22 +90,27 @@ jobs:
       # no local copy exists since the build step pushed straight to the registry.
       - script: |
           curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
-          docker scout cves gluwa/cc3-staking-dashboard:$(Build.BuildId) --exit-code=false
+          docker scout cves gluwa/cc3-staking-dashboard:$(Build.BuildId)
         displayName: 'Docker Scout CVE scan (informational, non-blocking)'
         continueOnError: true
 
   - job: 'WeeklyScoutReport'
     condition: eq(variables['Build.Reason'], 'Schedule')
     steps:
-      - task: Docker@2
-        displayName: 'Docker login (Docker Scout org policy evaluation)'
-        inputs:
-          containerRegistry: 'substrate-relayer'
-          command: 'login'
-
       - script: |
           curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
         displayName: 'Install Docker Scout CLI'
+
+      # Plain `docker login`, not Docker@2 - the Docker@2 login task doesn't leave
+      # `docker scout` authenticated (confirmed: quickview came back with the "log in"
+      # prompt as its output, even though the same Docker@2 login is enough for buildx
+      # push in the job above). Mirrors creditcoin3's working GitHub Actions equivalent.
+      - script: |
+          echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        displayName: 'Docker Hub login (Docker Scout org policy evaluation)'
+        env:
+          DOCKERHUB_USERNAME: $(DOCKERHUB_USERNAME)
+          DOCKERHUB_PASSWORD: $(DOCKERHUB_PASSWORD)
 
       # Scans the published :latest image and posts to #noti-docker-scout via the
       # Penguin Patrol docker-scout-report type (raw quickview per image; Penguin Patrol


### PR DESCRIPTION
## Summary
- `WeeklyScoutReport`'s `Docker@2` login task left `docker scout` unauthenticated, so the weekly report posted `Policy UNKNOWN / Critical ? · High ? · Medium ? · Low ?` to `#noti-docker-scout` instead of real data
- Replaced it with a plain-script `docker login` using `dockerhub-gluwabot` credentials (new `DOCKERHUB_USERNAME`/`DOCKERHUB_PASSWORD` secrets in the `PenguinPatrol` Azure DevOps variable group), mirroring creditcoin3's working GitHub Actions equivalent
- Also dropped an invalid `--exit-code` flag from `BuildAndPush`'s informational Scout CVE scan (`docker scout cves` has no such flag — was failing silently on every build)

## Test plan
- [x] Verified live: temporarily overrode both jobs' `condition:` to force `WeeklyScoutReport` to run on-demand (build 98238), confirmed `Login Succeeded` and a real report reached `#noti-docker-scout` (`Policy FAILED 5/7, Critical 0 · High 2 · Medium 8 · Low 2 · Unknown 32`), then reverted the conditions back to their original schedule-only logic before this commit
- [x] `BuildAndPush` job untouched aside from the flag removal — no behavior change to build/push itself

Closes DO-2330