### PR TITLE
[DO-2437] Decouple Weekly Docker Scout Report From CD Release Trigger

### DIFF
--- a/creditcoin-staking-dashboard-ci.yml
+++ b/creditcoin-staking-dashboard-ci.yml
@@ -12,14 +12,6 @@ pr:
   - master
   - dev
 
-schedules:
-  - cron: '0 13 * * 1'
-    displayName: 'Weekly Docker Scout report (Mon 09:00 EDT)'
-    branches:
-      include:
-        - dev
-    always: true
-
 variables:
   - group: PenguinPatrol
 
@@ -28,7 +20,6 @@ pool:
 
 jobs:
   - job: 'BuildAndPush'
-    condition: ne(variables['Build.Reason'], 'Schedule')
     steps:
       - pwsh: |
           $branchtag=""
@@ -93,37 +84,3 @@ jobs:
           docker scout cves gluwa/cc3-staking-dashboard:$(Build.BuildId)
         displayName: 'Docker Scout CVE scan (informational, non-blocking)'
         continueOnError: true
-
-  - job: 'WeeklyScoutReport'
-    condition: eq(variables['Build.Reason'], 'Schedule')
-    steps:
-      - script: |
-          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
-        displayName: 'Install Docker Scout CLI'
-
-      # Plain `docker login`, not Docker@2 - the Docker@2 login task doesn't leave
-      # `docker scout` authenticated (confirmed: quickview came back with the "log in"
-      # prompt as its output, even though the same Docker@2 login is enough for buildx
-      # push in the job above). Mirrors creditcoin3's working GitHub Actions equivalent.
-      - script: |
-          echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-        displayName: 'Docker Hub login (Docker Scout org policy evaluation)'
-        env:
-          DOCKERHUB_USERNAME: $(DOCKERHUB_USERNAME)
-          DOCKERHUB_PASSWORD: $(DOCKERHUB_PASSWORD)
-
-      # Scans the published :latest image and posts to #noti-docker-scout via the
-      # Penguin Patrol docker-scout-report type (raw quickview per image; Penguin Patrol
-      # parses + formats — one Slack block per image). IMAGES passed via env, never inline.
-      - script: |
-          set -euo pipefail
-          QV=$(docker scout quickview gluwa/cc3-staking-dashboard:latest 2>&1 || true)
-          IMAGES=$(jq -n --arg qv "$QV" '[{label: "cc3-staking-dashboard", tag: "latest", quickview: $qv}]')
-          PAYLOAD=$(jq -n --argjson images "$IMAGES" \
-            '{alertName: "docker-scout-report", alertTitle: "Weekly Docker Scout Report — cc3-staking-dashboard", channel_name: "#noti-docker-scout", images: $images}')
-          HTTP=$(curl -s -o /tmp/pp_resp.txt -w '%{http_code}' -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD")
-          if [ "$HTTP" -ge 400 ]; then echo "Penguin Patrol webhook rejected (HTTP $HTTP):"; cat /tmp/pp_resp.txt; exit 1; fi
-          echo "Posted weekly Scout report to Penguin Patrol (HTTP $HTTP)."
-        displayName: 'Weekly report to Penguin Patrol'
-        env:
-          WEBHOOK_URL: $(PENGUIN_PATROL_WEBHOOK_URL)

--- a/docker-scout-weekly-report.yml
+++ b/docker-scout-weekly-report.yml
@@ -1,0 +1,50 @@
+trigger: none
+pr: none
+
+schedules:
+  - cron: '0 13 * * 1'
+    displayName: 'Weekly Docker Scout report (Mon 09:00 EDT)'
+    branches:
+      include:
+        - dev
+    always: true
+
+variables:
+  - group: PenguinPatrol
+
+pool:
+  vmImage: ubuntu-latest
+
+jobs:
+  - job: 'WeeklyScoutReport'
+    steps:
+      - script: |
+          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s --
+        displayName: 'Install Docker Scout CLI'
+
+      # Plain `docker login`, not Docker@2 - the Docker@2 login task doesn't leave
+      # `docker scout` authenticated (confirmed: quickview came back with the "log in"
+      # prompt as its output, even though the same Docker@2 login is enough for buildx
+      # push in the CI pipeline). Mirrors creditcoin3's working GitHub Actions equivalent.
+      - script: |
+          echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        displayName: 'Docker Hub login (Docker Scout org policy evaluation)'
+        env:
+          DOCKERHUB_USERNAME: $(DOCKERHUB_USERNAME)
+          DOCKERHUB_PASSWORD: $(DOCKERHUB_PASSWORD)
+
+      # Scans the published :latest image and posts to #noti-docker-scout via the
+      # Penguin Patrol docker-scout-report type (raw quickview per image; Penguin Patrol
+      # parses + formats — one Slack block per image). IMAGES passed via env, never inline.
+      - script: |
+          set -euo pipefail
+          QV=$(docker scout quickview gluwa/cc3-staking-dashboard:latest 2>&1 || true)
+          IMAGES=$(jq -n --arg qv "$QV" '[{label: "cc3-staking-dashboard", tag: "latest", quickview: $qv}]')
+          PAYLOAD=$(jq -n --argjson images "$IMAGES" \
+            '{alertName: "docker-scout-report", alertTitle: "Weekly Docker Scout Report — cc3-staking-dashboard", channel_name: "#noti-docker-scout", images: $images}')
+          HTTP=$(curl -s -o /tmp/pp_resp.txt -w '%{http_code}' -X POST "$WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD")
+          if [ "$HTTP" -ge 400 ]; then echo "Penguin Patrol webhook rejected (HTTP $HTTP):"; cat /tmp/pp_resp.txt; exit 1; fi
+          echo "Posted weekly Scout report to Penguin Patrol (HTTP $HTTP)."
+        displayName: 'Weekly report to Penguin Patrol'
+        env:
+          WEBHOOK_URL: $(PENGUIN_PATROL_WEBHOOK_URL)


### PR DESCRIPTION
Related Jira Task: DO-2437 (https://gluwa.atlassian.net/browse/DO-2437)

Changes in this PR:
- Removed the `schedules:` cron trigger and the `WeeklyScoutReport` job from `creditcoin-staking-dashboard-ci.yml`
- Added `docker-scout-weekly-report.yml`, a standalone pipeline holding just the weekly cron trigger and the scan/report job, with `trigger: none` and `pr: none` so it only ever fires on schedule
- Once this file is registered as its own Azure DevOps build pipeline, its scheduled runs live on a build definition release 119 has never seen, so it can no longer auto-trigger a broken deploy off the scan build

Testing/Verification:
- `creditcoin-staking-dashboard-ci.yml`'s existing trigger config (dev/release/feature/project branches, PR validation) is untouched, only the schedule and report job were removed
- After merge, a new build pipeline needs to be registered pointing at `docker-scout-weekly-report.yml` (separate Azure DevOps step, tracked in DO-2437)
- Once registered, confirm the next Monday run (8/17) posts to #noti-docker-scout and does not touch release 119