### PR TITLE
fix(DO-2444): use corepack to activate yarn 3.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG TARGET_NETWORK=""
 
 WORKDIR /app
 COPY . .
-RUN yarn policies set-version '3.3.1'
+RUN corepack enable && corepack prepare yarn@3.3.1 --activate
 
 RUN yarn install \
 && VITE_ENVIRONMENT=${TARGET_NETWORK} yarn build


### PR DESCRIPTION
## Summary
- `yarn policies set-version '3.3.1'` fails Docker builds repo-wide with a `fs.writeFile` TypeError inside Yarn Classic's bootstrap — confirmed unrelated to any code change by re-running the GitHub Actions "Docker" workflow against `dev`'s own last known-good commit, which now fails identically.
- Replaces it with `corepack enable && corepack prepare yarn@3.3.1 --activate`, achieving the same pinned-Yarn-3.3.1 result via Node's built-in Corepack instead of the broken Yarn Classic write path.

## Verification
- `docker build --target build` succeeds end-to-end locally (install + `yarn build` via Vite).
- `yarn --version` inside the built image reports `3.3.1` as expected.

Closes DO-2444